### PR TITLE
DeleteView template name incorrect?

### DIFF
--- a/vanilla/model_views.py
+++ b/vanilla/model_views.py
@@ -153,7 +153,7 @@ class GenericModelView(View):
             fmt = '%s_list' if is_list else '%s'
             return fmt % self.model._meta.object_name.lower()
 
-        return None 
+        return None
 
     def get_context_data(self, **kwargs):
         """
@@ -325,7 +325,7 @@ class UpdateView(GenericModelView):
 
 class DeleteView(GenericModelView):
     success_url = None
-    template_name_suffix = '_detail'
+    template_name_suffix = '_confirm_delete'
 
     def get(self, request, *args, **kwargs):
         self.object = self.get_object()

--- a/vanilla/tests.py
+++ b/vanilla/tests.py
@@ -384,7 +384,7 @@ class TestDelete(BaseTestCase):
         response = self.get(view, pk=pk)
 
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.template_name, ['vanilla/example_detail.html'])
+        self.assertEqual(response.template_name, ['vanilla/example_confirm_delete.html'])
         self.assertContext(response, {
             'object': Example.objects.get(pk=pk),
             'example': Example.objects.get(pk=pk),


### PR DESCRIPTION
Hi Tom.  Have been having a play with this, but hit something unexpected - the DeleteView is using the same template name as the DetailView.  If it's a typo, here's a fix, if it's by design then I guess it needs documenting somewhere.  Seems useful to have it use the same template, as it means it drops into my existing project without any changes, but maybe there's a reason to change it.  Cheers dude :)
