### PR TITLE
Allow keyword based URL parameters

### DIFF
--- a/vanilla/views.py
+++ b/vanilla/views.py
@@ -81,7 +81,7 @@ class FormView(GenericView):
         context = self.get_context_data(form=form)
         return self.render_to_response(context)
 
-    def post(self, request):
+    def post(self, request, *args, **kwargs):
         form = self.get_form(data=request.POST, files=request.FILES)
         if form.is_valid():
             return self.form_valid(form)


### PR DESCRIPTION
Without this, you will get an error like "post() got an unexpected keyword argument 'pk'" if you have parameters in the URL such as "url(r'^profiles/(?P<pk>\d)/contact$', views.ContactView.as_view(), name='contact'),"
