### PR TITLE
Add view kwargs (e.g. from URL mapping) to rendering context

### DIFF
--- a/vanilla/views.py
+++ b/vanilla/views.py
@@ -69,7 +69,7 @@ class GenericView(View):
 
 class TemplateView(GenericView):
     def get(self, request, *args, **kwargs):
-        context = self.get_context_data()
+        context = self.get_context_data(**kwargs)
         return self.render_to_response(context)
 
 
@@ -78,20 +78,20 @@ class FormView(GenericView):
 
     def get(self, request, *args, **kwargs):
         form = self.get_form()
-        context = self.get_context_data(form=form)
+        context = self.get_context_data(form=form, **kwargs)
         return self.render_to_response(context)
 
     def post(self, request, *args, **kwargs):
         form = self.get_form(data=request.POST, files=request.FILES)
         if form.is_valid():
-            return self.form_valid(form)
-        return self.form_invalid(form)
+            return self.form_valid(form, **kwargs)
+        return self.form_invalid(form, **kwargs)
 
-    def form_valid(self, form):
+    def form_valid(self, form, **kwargs):
         return HttpResponseRedirect(self.get_success_url())
 
-    def form_invalid(self, form):
-        context = self.get_context_data(form=form)
+    def form_invalid(self, form, **kwargs):
+        context = self.get_context_data(form=form, **kwargs)
         return self.render_to_response(context)
 
     def get_success_url(self):


### PR DESCRIPTION
I was wondering what happened to the `kwargs` passed to the `get()` method.
So I checked `TemplateView` and found this:

```
class TemplateView(GenericView):
    def get(self, request, *args, **kwargs):
        context = self.get_context_data()
        return self.render_to_response(context)
```

I.e. the kwargs are completely ignored and discarded.

How about passing them to `get_context_data` instead? Then we can write our
URLs with keyword argument placeholders:

```
url(r'^commitment/(?P<declaration>\S+)/(?P<commitment>\S+)/(?P<country>\S+)$',
    views.CommitmentComparison.as_view(), name='commitment-comparison'),
```

and those parameters will end up in our context, and hence available to the
template, without any extra work.
