### PR TITLE
Clean up Travis and Tox test configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ python:
     - "3.4"
 
 env:
-    - DJANGO="django==1.3.7 --use-mirrors"
-    - DJANGO="django==1.4.5 --use-mirrors"
-    - DJANGO="django==1.5.1 --use-mirrors"
-    - DJANGO="django==1.6.1 --use-mirrors"
-    - DJANGO="https://www.djangoproject.com/download/1.7c1/tarball/"
+    - DJANGO="1.3.7"
+    - DJANGO="1.4.16"
+    - DJANGO="1.5.11"
+    - DJANGO="1.6.8"
+    - DJANGO="1.7.1"
 
 install:
-    - pip install $DJANGO
+    - pip install Django==$DJANGO --use-mirrors
     - pip install coverage==3.6
     - pip install python-coveralls==2.4.0
     - export PYTHONPATH=.
@@ -29,21 +29,21 @@ after_success: coverage report; coveralls
 matrix:
     exclude:
         - python: "2.6"
-          env: DJANGO="https://www.djangoproject.com/download/1.7c1/tarball/"
+          env: DJANGO="1.7.1"
         - python: "3.2"
-          env: DJANGO="django==1.4.5 --use-mirrors"
+          env: DJANGO="1.4.16"
         - python: "3.2"
-          env: DJANGO="django==1.3.7 --use-mirrors"
+          env: DJANGO="1.3.7"
         - python: "3.3"
-          env: DJANGO="django==1.4.5 --use-mirrors"
+          env: DJANGO="1.4.16"
         - python: "3.3"
-          env: DJANGO="django==1.3.7 --use-mirrors"
+          env: DJANGO="1.3.7"
         - python: "3.4"
-          env: DJANGO="django==1.6.1 --use-mirrors"
+          env: DJANGO="1.6.8"
         - python: "3.4"
-          env: DJANGO="django==1.5.1 --use-mirrors"
+          env: DJANGO="1.5.11"
         - python: "3.4"
-          env: DJANGO="django==1.4.5 --use-mirrors"
+          env: DJANGO="1.4.16"
         - python: "3.4"
-          env: DJANGO="django==1.3.7 --use-mirrors"
+          env: DJANGO="1.3.7"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,87 +1,16 @@
 [tox]
 envlist =
-    py2.6-d1.3, py2.6-d1.4, py2.6-d1.5, py2.6-d1.6,
-    py2.7-d1.3, py2.7-d1.4, py2.7-d1.5, py2.7-d1.6, py2.7-d1.7,
-    py3.2-d1.5, py3.2-d1.6, py3.2-d1.7,
-    py3.3-d1.5, py3.3-d1.6, py3.3-d1.7,
-    py3.4-d1.7
+    dj13-py{26,27},
+    dj14-py{26,27},
+    dj15-py{26,27,32,33},
+    dj16-py{26,27,32,33},
+    dj17-py{27,32,33,34},
 
 [testenv]
 commands = {envpython} manage.py test
-
-
-# Python 2.6
-
-[testenv:py2.6-d1.3]
-basepython = python2.6
-deps = django>=1.3,<1.4
-
-[testenv:py2.6-d1.4]
-basepython = python2.6
-deps = django>=1.4,<1.5
-
-[testenv:py2.6-d1.5]
-basepython = python2.6
-deps = django>=1.5,<1.6
-
-[testenv:py2.6-d1.6]
-basepython = python2.6
-deps = django>=1.6,<1.7
-
-
-# Python 2.7
-
-[testenv:py2.7-d1.3]
-basepython = python2.7
-deps = django>=1.3,<1.4
-
-[testenv:py2.7-d1.4]
-basepython = python2.7
-deps = django>=1.4,<1.5
-
-[testenv:py2.7-d1.5]
-basepython = python2.7
-deps = django>=1.5,<1.6
-
-[testenv:py2.7-d1.6]
-basepython = python2.7
-deps = django>=1.6,<1.7
-
-[testenv:py2.7-d1.7]
-basepython = python2.7
-deps = https://www.djangoproject.com/download/1.7c1/tarball/
-
-# Python 3.2
-
-[testenv:py3.2-d1.5]
-basepython = python3.3
-deps = django>=1.5,<1.6
-
-[testenv:py3.2-d1.6]
-basepython = python3.3
-deps = django>=1.6,<1.7
-
-[testenv:py3.2-d1.7]
-basepython = python3.3
-deps = https://www.djangoproject.com/download/1.7c1/tarball/
-
-# Python 3.3
-
-[testenv:py3.3-d1.5]
-basepython = python3.3
-deps = django>=1.5,<1.6
-
-[testenv:py3.3-d1.6]
-basepython = python3.3
-deps = django>=1.6,<1.7
-
-[testenv:py3.3-d1.7]
-basepython = python3.3
-deps = https://www.djangoproject.com/download/1.7c1/tarball/
-
-# Python 3.4
-
-[testenv:py3.4-d1.7]
-basepython = python3.3
-deps = https://www.djangoproject.com/download/1.7c1/tarball/
-
+deps =
+    dj13: django>=1.3,<1.4
+    dj14: django>=1.4,<1.5
+    dj15: django>=1.5,<1.6
+    dj16: django>=1.6,<1.7
+    dj17: django>=1.7,<1.8


### PR DESCRIPTION
This should fix #33 as well.
- Use the release version of Django 1.7
- Use the latest patch version of all Django versions
- Simplify Travis DJANGO env variable

Also drastically simplify the tox.ini file.
- Use the new generative envlist feature to drastically simplify
  the envlist build matrix.
- Organize the envlist by Django version over Python version,
  since we're more likely to add and drop support by Django
  version than Python version.
- Use `pyXX` for the python version of the envlist name, to match
  the built-in envs from Tox.
- Use Tox factors to avoid creating separate sections for each
  env in the envlist.
- Let Tox set the basepython automatically from the envlist name,
  since that is now in the same format as the builtin envs.
