### PR TITLE
docs: update the deprecated build badge

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@
 
 **Beautifully simple class-based views.**
 
-[![Build Status](https://img.shields.io/github/workflow/status/encode/django-vanilla-views/CI/master?style=for-the-badge)](https://github.com/encode/django-vanilla-views/actions?workflow=CI) [![PyPI version](https://img.shields.io/pypi/v/django-vanilla-views.svg?style=for-the-badge)](https://pypi.org/project/django-vanilla-views/)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/encode/django-vanilla-views/main.yml?branch=master&style=for-the-badge)](https://github.com/encode/django-vanilla-views/actions?workflow=CI) [![PyPI version](https://img.shields.io/pypi/v/django-vanilla-views.svg?style=for-the-badge)](https://pypi.org/project/django-vanilla-views/)
 
     View --+------------------------- RedirectView
            |


### PR DESCRIPTION
Hello, this PR fixes the deprecated badge image to the new one. Thanks!

Target file: https://github.com/encode/django-vanilla-views/blob/master/docs/index.md

**Before**
![Screenshot from 2024-02-14 11-36-37](https://github.com/encode/django-vanilla-views/assets/1425259/baaae9cb-777a-4663-bdd5-21c7d59b139a)

**After**
![Screenshot from 2024-02-14 11-35-13](https://github.com/encode/django-vanilla-views/assets/1425259/21282048-616b-4b56-85b1-9a4d20e2e819)

Issue explaining about the deprecation: https://github.com/badges/shields/issues/8671

**CI error**

It looks like `pre-commit` error in GitHub Actions is related to `isort` issue. Probably we need to upgrade its version. (ref. https://github.com/home-assistant/core/issues/86892)